### PR TITLE
Initialize Next.js note app skeleton

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["next/core-web-vitals"]
+}
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# supanote
+# Supanote
+
+Supanote is a minimal note taking application built with Next.js and
+prepared for future integration with Supabase. It demonstrates a clean
+application structure with TypeScript, React Context for state management
+and Tailwind CSS for styling.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Testing
+
+```bash
+npm test
+npm run lint
+```
+
+The project currently stores notes in `localStorage`. A Supabase backend
+can be added later in the context layer.
+

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,9 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+};
+
+export default nextConfig;
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "supanote",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "next": "14.2.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.30",
+    "@types/react": "18.2.33",
+    "autoprefixer": "10.4.16",
+    "eslint": "8.51.0",
+    "eslint-config-next": "14.2.4",
+    "postcss": "8.4.32",
+    "tailwindcss": "3.4.1",
+    "typescript": "5.3.3",
+    "vitest": "1.0.4"
+  }
+}
+

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,7 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-50;
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,16 @@
+import './globals.css';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Supanote',
+  description: 'Simple note app built with Next.js',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,17 @@
+import NoteForm from '@/components/NoteForm';
+import NoteList from '@/components/NoteList';
+import { NotesProvider } from '@/context/NotesContext';
+
+export default function Home() {
+  return (
+    <NotesProvider>
+      <main className="max-w-2xl mx-auto p-4">
+        <h1 className="text-2xl font-bold mb-4">Supanote</h1>
+        <NoteForm />
+        <div className="my-4" />
+        <NoteList />
+      </main>
+    </NotesProvider>
+  );
+}
+

--- a/src/components/NoteForm.tsx
+++ b/src/components/NoteForm.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useState } from 'react';
+import { useNotes } from '@/context/NotesContext';
+
+export default function NoteForm() {
+  const { add } = useNotes();
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim() && !content.trim()) return;
+    add(title, content);
+    setTitle('');
+    setContent('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <input
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Title"
+        className="w-full border p-2 rounded"
+      />
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder="Content"
+        className="w-full border p-2 rounded"
+      />
+      <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+        Add Note
+      </button>
+    </form>
+  );
+}
+

--- a/src/components/NoteList.tsx
+++ b/src/components/NoteList.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useNotes } from '@/context/NotesContext';
+
+export default function NoteList() {
+  const { notes, remove } = useNotes();
+
+  if (notes.length === 0) {
+    return <p className="text-gray-500">No notes yet</p>;
+  }
+
+  return (
+    <ul className="space-y-2">
+      {notes.map((n) => (
+        <li key={n.id} className="border p-2 rounded">
+          <div className="flex justify-between items-start">
+            <div>
+              <h3 className="font-semibold">{n.title}</h3>
+              <p>{n.content}</p>
+            </div>
+            <button onClick={() => remove(n.id)} className="text-red-600">
+              Delete
+            </button>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+

--- a/src/context/NotesContext.tsx
+++ b/src/context/NotesContext.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { createNote, addNote, removeNote } from '@/lib/noteStore';
+import { Note } from '@/types/note';
+
+interface NotesContextValue {
+  notes: Note[];
+  add: (title: string, content: string) => void;
+  remove: (id: string) => void;
+}
+
+const NotesContext = createContext<NotesContextValue | undefined>(undefined);
+
+export const NotesProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [notes, setNotes] = useState<Note[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('notes');
+    if (stored) {
+      setNotes(JSON.parse(stored));
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('notes', JSON.stringify(notes));
+  }, [notes]);
+
+  const add = (title: string, content: string) => {
+    const note = createNote({ title, content });
+    setNotes((prev) => addNote(prev, note));
+  };
+
+  const remove = (id: string) => {
+    setNotes((prev) => removeNote(prev, id));
+  };
+
+  return (
+    <NotesContext.Provider value={{ notes, add, remove }}>
+      {children}
+    </NotesContext.Provider>
+  );
+};
+
+export const useNotes = () => {
+  const ctx = useContext(NotesContext);
+  if (!ctx) throw new Error('useNotes must be used within NotesProvider');
+  return ctx;
+};
+

--- a/src/lib/noteStore.test.ts
+++ b/src/lib/noteStore.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { addNote, createNote, removeNote } from './noteStore';
+
+describe('noteStore', () => {
+  it('adds and removes a note', () => {
+    const note = createNote({ title: 'test', content: 'hello' });
+    let notes = addNote([], note);
+    expect(notes).toHaveLength(1);
+    notes = removeNote(notes, note.id);
+    expect(notes).toHaveLength(0);
+  });
+});
+

--- a/src/lib/noteStore.ts
+++ b/src/lib/noteStore.ts
@@ -1,0 +1,18 @@
+import { Note } from '@/types/note';
+
+export function createNote(data: Omit<Note, 'id' | 'createdAt'>): Note {
+  return {
+    id: crypto.randomUUID(),
+    createdAt: Date.now(),
+    ...data,
+  };
+}
+
+export function addNote(notes: Note[], note: Note): Note[] {
+  return [...notes, note];
+}
+
+export function removeNote(notes: Note[], id: string): Note[] {
+  return notes.filter((n) => n.id !== id);
+}
+

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -1,0 +1,7 @@
+export interface Note {
+  id: string;
+  title: string;
+  content: string;
+  createdAt: number;
+}
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+});
+


### PR DESCRIPTION
## Summary
- scaffold Next.js app structure with TypeScript and Tailwind
- add React context, components, and utilities for client-side note taking
- include Vitest setup and initial unit test for note storage

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd747858448332b2e02d966691a069