### PR TITLE
fix: remove type imports from next config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,5 @@
-import type { NextConfig } from 'next';
-
-const nextConfig: NextConfig = {
+/** @type {import('next').NextConfig} */
+const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
 };


### PR DESCRIPTION
## Summary
- use JSDoc instead of TypeScript syntax in `next.config.mjs`

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run build` *(fails: sh: 1: next: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bd774e528c833280db0f4e62124f32