### PR TITLE
feat: save notes to supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Supabase/Postgres connection string
+DATABASE_URL="postgresql://postgres:Nitesh@+1@db.ppxjampjhrzpodsvyuiw.supabase.co:5432/postgres"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+.env
+.env.local
+.env.*.local
+

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/node": "20.11.30",
     "@types/react": "18.2.33",
+    "@types/pg": "8.10.5",
     "autoprefixer": "10.4.16",
     "eslint": "8.51.0",
     "eslint-config-next": "14.2.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "next": "14.2.4",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "pg": "8.11.3"
   },
   "devDependencies": {
     "@types/node": "20.11.30",

--- a/src/app/api/notes/route.ts
+++ b/src/app/api/notes/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import type { Note } from '@/types/note';
+
+export async function POST(req: Request) {
+  const note: Note = await req.json();
+  const { Pool } = await import('pg');
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  await pool.query(
+    'insert into notes (id, title, content, created_at) values ($1, $2, $3, to_timestamp($4 / 1000.0))',
+    [note.id, note.title, note.content, note.createdAt]
+  );
+  return NextResponse.json({ success: true });
+}

--- a/src/components/NoteForm.tsx
+++ b/src/components/NoteForm.tsx
@@ -8,10 +8,10 @@ export default function NoteForm() {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim() && !content.trim()) return;
-    add(title, content);
+    await add(title, content);
     setTitle('');
     setContent('');
   };

--- a/src/context/NotesContext.tsx
+++ b/src/context/NotesContext.tsx
@@ -6,7 +6,7 @@ import { Note } from '@/types/note';
 
 interface NotesContextValue {
   notes: Note[];
-  add: (title: string, content: string) => void;
+  add: (title: string, content: string) => Promise<void>;
   remove: (id: string) => void;
 }
 
@@ -26,9 +26,18 @@ export const NotesProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     localStorage.setItem('notes', JSON.stringify(notes));
   }, [notes]);
 
-  const add = (title: string, content: string) => {
+  const add = async (title: string, content: string) => {
     const note = createNote({ title, content });
     setNotes((prev) => addNote(prev, note));
+    try {
+      await fetch('/api/notes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(note),
+      });
+    } catch (err) {
+      console.error('Failed to save note', err);
+    }
   };
 
   const remove = (id: string) => {


### PR DESCRIPTION
## Summary
- add API route to persist notes in Supabase Postgres
- save notes through context and form using API endpoint
- document database connection and ignore local env artifacts

## Testing
- `npm test`
- `npm run lint`
- `npm install pg@8.11.3` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bd78c218488332b030fa35bae0a717