### PR TITLE
Alert on failed note save and show success check

### DIFF
--- a/src/components/NoteList.tsx
+++ b/src/components/NoteList.tsx
@@ -15,7 +15,10 @@ export default function NoteList() {
         <li key={n.id} className="border p-2 rounded">
           <div className="flex justify-between items-start">
             <div>
-              <h3 className="font-semibold">{n.title}</h3>
+              <h3 className="font-semibold flex items-center">
+                {n.title}
+                <span className="text-green-600 ml-2">✓</span>
+              </h3>
               <p>{n.content}</p>
             </div>
             <button onClick={() => remove(n.id)} className="text-red-600">

--- a/src/context/NotesContext.tsx
+++ b/src/context/NotesContext.tsx
@@ -28,14 +28,19 @@ export const NotesProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   const add = async (title: string, content: string) => {
     const note = createNote({ title, content });
-    setNotes((prev) => addNote(prev, note));
     try {
-      await fetch('/api/notes', {
+      const res = await fetch('/api/notes', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(note),
       });
+      if (!res.ok) {
+        throw new Error('Request failed');
+      }
+      setNotes((prev) => addNote(prev, note));
     } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      alert(`Failed to save note: ${message}`);
       console.error('Failed to save note', err);
     }
   };


### PR DESCRIPTION
## Summary
- alert user if note fails to save to backend
- display green check for notes successfully saved

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd7cf3432883328b01ae4b860a90ba