### PR TITLE
Use Supabase client via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
-# Supabase/Postgres connection string
-DATABASE_URL="postgresql://postgres:Nitesh@+1@db.ppxjampjhrzpodsvyuiw.supabase.co:5432/postgres"
+# Supabase credentials
+NEXT_PUBLIC_SUPABASE_URL="https://your-supabase-project.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="your-anon-key"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "next": "14.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "pg": "8.11.3"
+    "pg": "8.11.3",
+    "@supabase/supabase-js": "^2.43.1"
   },
   "devDependencies": {
     "@types/node": "20.11.30",

--- a/src/app/api/notes/route.ts
+++ b/src/app/api/notes/route.ts
@@ -1,13 +1,19 @@
 import { NextResponse } from 'next/server';
 import type { Note } from '@/types/note';
+import { supabase } from '@/lib/supabase';
 
 export async function POST(req: Request) {
   const note: Note = await req.json();
-  const { Pool } = await import('pg');
-  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
-  await pool.query(
-    'insert into notes (id, title, content, created_at) values ($1, $2, $3, to_timestamp($4 / 1000.0))',
-    [note.id, note.title, note.content, note.createdAt]
-  );
+  const { error } = await supabase.from('notes').insert({
+    id: note.id,
+    title: note.title,
+    content: note.content,
+    created_at: new Date(note.createdAt).toISOString(),
+  });
+
+  if (error) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+
   return NextResponse.json({ success: true });
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,10 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!url || !anonKey) {
+  throw new Error('Missing Supabase environment variables');
+}
+
+export const supabase = createClient(url, anonKey);


### PR DESCRIPTION
## Summary
- set up Supabase client that reads `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`
- insert notes through Supabase instead of direct PG connection
- document required Supabase environment variables and declare dependency

## Testing
- `npm test`
- `npm install @supabase/supabase-js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7fc93f5c8332809749e582ce78d1