### PR TITLE
Integrate Supabase note persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,11 +3,17 @@
 import { useState } from 'react';
 import NoteForm from '../components/NoteForm';
 import NoteList from '../components/NoteList';
+import { supabase } from '../lib/supabase';
 
 export default function Page() {
   const [notes, setNotes] = useState<string[]>([]);
 
-  function addNote(text: string) {
+  async function addNote(text: string) {
+    const { error } = await supabase.from('notes').insert({ text });
+    if (error) {
+      alert('Failed to save note');
+      return;
+    }
     setNotes([...notes, text]);
   }
 

--- a/components/NoteForm.tsx
+++ b/components/NoteForm.tsx
@@ -2,14 +2,18 @@
 
 import { useState, FormEvent } from 'react';
 
-export default function NoteForm({ onAdd }: { onAdd: (text: string) => void }) {
+export default function NoteForm({
+  onAdd,
+}: {
+  onAdd: (text: string) => Promise<void>;
+}) {
   const [text, setText] = useState('');
 
-  function handleSubmit(e: FormEvent) {
+  async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     const trimmed = text.trim();
     if (!trimmed) return;
-    onAdd(trimmed);
+    await onAdd(trimmed);
     setText('');
   }
 

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "next": "14.1.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "@supabase/supabase-js": "^2.44.2"
   },
   "devDependencies": {
     "typescript": "5.3.3",


### PR DESCRIPTION
## Summary
- add Supabase client configured via env variables
- persist notes to Supabase when adding; alert on failure
- support async note submission in form

## Testing
- `npm install` *(fails: 403 Forbidden fetching @supabase/supabase-js)*
- `npm test`
- `npm run lint` *(fails: command prompts for interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68bd84f7227c83328b145fb203783986