### PR TITLE
Fix Supabase insert format to save notes

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,9 @@ export default function Page() {
   const [notes, setNotes] = useState<string[]>([]);
 
   async function addNote(text: string) {
-    const { error } = await supabase.from('notes').insert({ text });
+    // Supabase expects an array of objects for inserts. Sending a plain
+    // object causes an error and the note is not saved.
+    const { error } = await supabase.from('notes').insert([{ text }]);
     if (error) {
       alert('Failed to save note');
       return;


### PR DESCRIPTION
## Summary
- pass note data as an array when inserting into Supabase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd865650908332a2986b32caf0f117