### PR TITLE
Handle Supabase insert errors

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ export default function Page() {
     // object causes an error and the note is not saved.
     const { error } = await supabase.from('notes').insert([{ text }]);
     if (error) {
+      console.error('Failed to save note:', error);
       alert('Failed to save note');
       return;
     }


### PR DESCRIPTION
## Summary
- ensure notes are inserted as an array into Supabase
- log Supabase errors when note saves fail

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd875bcfb48332ab7eb6e9943ffcdf