### PR TITLE
Handle failed note saves gracefully

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,16 +8,17 @@ import { supabase } from '../lib/supabase';
 export default function Page() {
   const [notes, setNotes] = useState<string[]>([]);
 
-  async function addNote(text: string) {
+  async function addNote(text: string): Promise<boolean> {
     // Supabase expects an array of objects for inserts. Sending a plain
     // object causes an error and the note is not saved.
     const { error } = await supabase.from('notes').insert([{ text }]);
     if (error) {
       console.error('Failed to save note:', error);
       alert('Failed to save note');
-      return;
+      return false;
     }
     setNotes([...notes, text]);
+    return true;
   }
 
   function deleteNote(index: number) {

--- a/components/NoteForm.tsx
+++ b/components/NoteForm.tsx
@@ -5,7 +5,9 @@ import { useState, FormEvent } from 'react';
 export default function NoteForm({
   onAdd,
 }: {
-  onAdd: (text: string) => Promise<void>;
+  // Return a boolean so the form knows whether the save succeeded.
+  // This lets us avoid clearing the input on failure.
+  onAdd: (text: string) => Promise<boolean>;
 }) {
   const [text, setText] = useState('');
 
@@ -13,8 +15,10 @@ export default function NoteForm({
     e.preventDefault();
     const trimmed = text.trim();
     if (!trimmed) return;
-    await onAdd(trimmed);
-    setText('');
+    const saved = await onAdd(trimmed);
+    if (saved) {
+      setText('');
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- don't clear the note input when Supabase insert fails
- surface insert success back to the form via boolean return value

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bd891dca2083328aed206f6b3bc25e