### PR TITLE
Use functional state updates for note actions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,12 +17,13 @@ export default function Page() {
       alert('Failed to save note');
       return false;
     }
-    setNotes([...notes, text]);
+    // Use functional update to avoid stale state when adding notes
+    setNotes((current) => [...current, text]);
     return true;
   }
 
   function deleteNote(index: number) {
-    setNotes(notes.filter((_, i) => i !== index));
+    setNotes((current) => current.filter((_, i) => i !== index));
   }
 
   return (


### PR DESCRIPTION
## Summary
- use functional updates when adding a note to avoid stale state
- use functional updates when deleting notes to keep state consistent

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8aa3853c83329a4c05535076f1d5