### PR TITLE
Show detailed error when note save fails

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ export default function Page() {
     const { error } = await supabase.from('notes').insert([{ text }]);
     if (error) {
       console.error('Failed to save note:', error);
-      alert('Failed to save note');
+      alert(`Failed to save note: ${error.message}`);
       return false;
     }
     // Use functional update to avoid stale state when adding notes


### PR DESCRIPTION
## Summary
- Display Supabase error message when note saving fails

## Testing
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8cdde0648332a97fc92a01febb8f