### PR TITLE
feat: add toggleable grid and list view for notes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -14,6 +14,42 @@ ul {
   padding: 0;
 }
 
-li {
-  margin-bottom: 0.5rem;
+.view-toggle {
+  margin-bottom: 1rem;
+}
+
+.notes-container {
+  display: grid;
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+}
+
+.notes-container.list {
+  grid-template-columns: 1fr;
+}
+
+.notes-container.grid {
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}
+
+.note-item {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 100px;
+}
+
+.note-text {
+  flex: 1;
+}
+
+.note-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
 }

--- a/components/NoteList.tsx
+++ b/components/NoteList.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 interface Note {
   id: string;
   text: string;
@@ -14,28 +16,42 @@ export default function NoteList({
   onDelete: (id: string) => void;
   onEdit: (id: string, text: string) => void;
 }) {
+  const [view, setView] = useState<'grid' | 'list'>('grid');
+
   if (notes.length === 0) {
     return <p>No notes yet.</p>;
   }
 
   return (
-    <ul>
-      {notes.map((note) => (
-        <li key={note.id}>
-          {note.text}
-          <button
-            onClick={() => {
-              const newText = prompt('Edit note', note.text);
-              if (newText !== null) {
-                onEdit(note.id, newText);
-              }
-            }}
-          >
-            Edit
-          </button>
-          <button onClick={() => onDelete(note.id)}>Delete</button>
-        </li>
-      ))}
-    </ul>
+    <>
+      <div className="view-toggle">
+        <button onClick={() => setView('grid')} disabled={view === 'grid'}>
+          Grid
+        </button>
+        <button onClick={() => setView('list')} disabled={view === 'list'}>
+          List
+        </button>
+      </div>
+      <ul className={`notes-container ${view}`}>
+        {notes.map((note) => (
+          <li key={note.id} className="note-item">
+            <span className="note-text">{note.text}</span>
+            <div className="note-actions">
+              <button
+                onClick={() => {
+                  const newText = prompt('Edit note', note.text);
+                  if (newText !== null) {
+                    onEdit(note.id, newText);
+                  }
+                }}
+              >
+                Edit
+              </button>
+              <button onClick={() => onDelete(note.id)}>Delete</button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add grid and list view toggle for note list
- introduce minimalist responsive styles for note containers

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9d825e8c8332b627ccfbba5c9c18