### PR TITLE
Add dark mode and refine note actions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,29 @@
+:root {
+  --bg: #ffffff;
+  --text: #111827;
+  --note-bg: #f9fafb;
+  --note-border: #e5e7eb;
+  --fab-bg: #3b82f6;
+  --fab-bg-hover: #2563eb;
+  --modal-bg: #ffffff;
+}
+
 body {
   margin: 0;
   font-family: Arial, sans-serif;
   padding: 2rem;
+  background: var(--bg);
+  color: var(--text);
+}
+
+body.dark {
+  --bg: #111827;
+  --text: #f3f4f6;
+  --note-bg: #1f2937;
+  --note-border: #374151;
+  --fab-bg: #2563eb;
+  --fab-bg-hover: #1d4ed8;
+  --modal-bg: #1f2937;
 }
 
 input, button, textarea {
@@ -40,8 +62,8 @@ ul {
 }
 
 .note-item {
-  background: #f9fafb;
-  border: 1px solid #e5e7eb;
+  background: var(--note-bg);
+  border: 1px solid var(--note-border);
   border-radius: 0.75rem;
   padding: 1rem;
   display: flex;
@@ -71,13 +93,28 @@ ul {
   margin-top: 0.5rem;
   opacity: 0;
   pointer-events: none;
+  visibility: hidden;
   transition: opacity 0.2s ease-in-out;
+}
+
+.note-actions button {
+  padding: 0.25rem;
+  border-radius: 0.375rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  margin-right: 0;
+}
+
+.note-actions button:hover {
+  background: var(--note-border);
 }
 
 .note-item:hover .note-actions,
 .note-item:focus-within .note-actions {
   opacity: 1;
   pointer-events: auto;
+  visibility: visible;
 }
 
 .fab {
@@ -85,7 +122,7 @@ ul {
   position: fixed;
   bottom: 1rem;
   right: 1rem;
-  background-color: #3b82f6;
+  background-color: var(--fab-bg);
   color: #fff;
   border: none;
   border-radius: 9999px;
@@ -99,7 +136,7 @@ ul {
 }
 
 .fab:hover {
-  background-color: #2563eb;
+  background-color: var(--fab-bg-hover);
 }
 
 .modal-overlay {
@@ -112,7 +149,7 @@ ul {
 }
 
 .modal {
-  background: #fff;
+  background: var(--modal-bg);
   padding: 1rem;
   border-radius: 0.75rem;
   display: flex;
@@ -124,7 +161,7 @@ ul {
 .save-button {
   margin-right: 0;
   align-self: flex-end;
-  background: #3b82f6;
+  background: var(--fab-bg);
   color: #fff;
   border: none;
   border-radius: 0.375rem;
@@ -133,5 +170,18 @@ ul {
 }
 
 .save-button:hover {
-  background: #2563eb;
+  background: var(--fab-bg-hover);
+}
+
+.theme-toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background: var(--note-bg);
+  color: var(--text);
+  border: 1px solid var(--note-border);
+  border-radius: 0.375rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  margin-right: 0;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,14 @@
 import './globals.css';
 import type { ReactNode } from 'react';
+import ThemeToggle from '../components/ThemeToggle';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <ThemeToggle />
+        {children}
+      </body>
     </html>
   );
 }

--- a/components/NoteList.tsx
+++ b/components/NoteList.tsx
@@ -78,10 +78,10 @@ export default function NoteList({
                   }
                 }}
               >
-                <EditIcon width={20} height={20} />
+                <EditIcon width={16} height={16} />
               </button>
               <button aria-label="Delete" onClick={() => onDelete(note.id)}>
-                <DeleteIcon width={20} height={20} />
+                <DeleteIcon width={16} height={16} />
               </button>
             </div>
           </li>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', dark);
+  }, [dark]);
+
+  return (
+    <button
+      className="theme-toggle"
+      onClick={() => setDark((d) => !d)}
+      aria-label="Toggle dark mode"
+    >
+      {dark ? 'Light' : 'Dark'}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add theme toggle to switch between light and dark modes
- shrink and round note action buttons, only active once visible
- centralize colors with CSS variables for light and dark styles

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68be3f54b14c833281a1c88b6bd9a0d6