### PR TITLE
feat: add title and date to notes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -87,6 +87,17 @@ ul {
   flex: 1;
 }
 
+.note-title {
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+
+.note-date {
+  font-size: 0.875rem;
+  color: var(--note-border);
+  margin-bottom: 0.5rem;
+}
+
 .note-actions {
   display: flex;
   gap: 0.5rem;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,9 @@ import { supabase } from '../lib/supabase';
 
 interface Note {
   id: string;
+  title: string;
   text: string;
+  date: string;
 }
 
 export default function Page() {
@@ -26,10 +28,14 @@ export default function Page() {
     loadNotes();
   }, []);
 
-  async function addNote(text: string): Promise<boolean> {
+  async function addNote(
+    title: string,
+    text: string,
+    date: string,
+  ): Promise<boolean> {
     const { data, error } = await supabase
       .from('notes')
-      .insert({ text })
+      .insert({ title, text, date })
       .select()
       .single();
     if (error) {
@@ -51,12 +57,17 @@ export default function Page() {
     setNotes((current) => current.filter((note) => note.id !== id));
   }
 
-  async function editNote(id: string, text: string): Promise<boolean> {
-    const trimmed = text.trim();
-    if (!trimmed) return false;
+  async function editNote(
+    id: string,
+    title: string,
+    text: string,
+  ): Promise<boolean> {
+    const trimmedTitle = title.trim();
+    const trimmedText = text.trim();
+    if (!trimmedText && !trimmedTitle) return false;
     const { error } = await supabase
       .from('notes')
-      .update({ text: trimmed })
+      .update({ title: trimmedTitle, text: trimmedText })
       .eq('id', id);
     if (error) {
       console.error('Failed to update note:', error);
@@ -64,7 +75,9 @@ export default function Page() {
       return false;
     }
     setNotes((current) =>
-      current.map((note) => (note.id === id ? { ...note, text: trimmed } : note))
+      current.map((note) =>
+        note.id === id ? { ...note, title: trimmedTitle, text: trimmedText } : note,
+      ),
     );
     return true;
   }

--- a/components/NoteForm.tsx
+++ b/components/NoteForm.tsx
@@ -6,21 +6,26 @@ import { PlusIcon } from './Icons';
 export default function NoteForm({
   onAdd,
 }: {
-  onAdd: (text: string) => Promise<boolean>;
+  onAdd: (title: string, text: string, date: string) => Promise<boolean>;
 }) {
+  const [title, setTitle] = useState('');
   const [text, setText] = useState('');
+  const [date, setDate] = useState(() => new Date().toISOString().split('T')[0]);
   const [open, setOpen] = useState(false);
 
   function close() {
     setOpen(false);
+    setTitle('');
     setText('');
+    setDate(new Date().toISOString().split('T')[0]);
   }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    const trimmed = text.trim();
-    if (!trimmed) return;
-    const saved = await onAdd(trimmed);
+    const trimmedTitle = title.trim();
+    const trimmedText = text.trim();
+    if (!trimmedText && !trimmedTitle) return;
+    const saved = await onAdd(trimmedTitle, trimmedText, date);
     if (saved) {
       close();
     }
@@ -34,6 +39,17 @@ export default function NoteForm({
       {open && (
         <div className="modal-overlay" onClick={close}>
           <form className="modal" onClick={(e) => e.stopPropagation()} onSubmit={handleSubmit}>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Title"
+            />
+            <input
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+            />
             <textarea
               autoFocus
               value={text}

--- a/components/NoteList.tsx
+++ b/components/NoteList.tsx
@@ -5,7 +5,9 @@ import { EditIcon, DeleteIcon } from './Icons';
 
 interface Note {
   id: string;
+  title: string;
   text: string;
+  date: string;
 }
 
 export default function NoteList({
@@ -15,7 +17,7 @@ export default function NoteList({
 }: {
   notes: Note[];
   onDelete: (id: string) => void;
-  onEdit: (id: string, text: string) => void;
+  onEdit: (id: string, title: string, text: string) => void;
 }) {
   const [view, setView] = useState<'grid' | 'list'>('grid');
   const [items, setItems] = useState(notes);
@@ -67,14 +69,20 @@ export default function NoteList({
             onDrop={handleDrop(index)}
             tabIndex={0}
           >
+            <span className="note-title">{note.title}</span>
+            <span className="note-date">
+              {new Date(note.date).toLocaleDateString()}
+            </span>
             <span className="note-text">{note.text}</span>
             <div className="note-actions">
               <button
                 aria-label="Edit"
                 onClick={() => {
+                  const newTitle = prompt('Edit title', note.title);
+                  if (newTitle === null) return;
                   const newText = prompt('Edit note', note.text);
                   if (newText !== null) {
-                    onEdit(note.id, newText);
+                    onEdit(note.id, newTitle, newText);
                   }
                 }}
               >


### PR DESCRIPTION
## Summary
- allow entering note titles and dates when creating notes
- show note title and formatted date in list
- support editing of note titles alongside text

## Testing
- `npm test`
- Attempted `CI=1 npm run lint` *(failed: interactive setup prompt)*
- Attempted `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build` *(output logged, but requires interactive tsconfig update)*

------
https://chatgpt.com/codex/tasks/task_e_68be444c1fe88332bd89f48da62fefeb