### PR TITLE
Use Supabase created_at for note timestamps

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ interface Note {
   id: string;
   title: string;
   text: string;
-  date: string;
+  created_at: string;
 }
 
 export default function Page() {
@@ -28,14 +28,10 @@ export default function Page() {
     loadNotes();
   }, []);
 
-  async function addNote(
-    title: string,
-    text: string,
-    date: string,
-  ): Promise<boolean> {
+  async function addNote(title: string, text: string): Promise<boolean> {
     const { data, error } = await supabase
       .from('notes')
-      .insert({ title, text, date })
+      .insert({ title, text })
       .select()
       .single();
     if (error) {

--- a/components/NoteForm.tsx
+++ b/components/NoteForm.tsx
@@ -6,18 +6,16 @@ import { PlusIcon } from './Icons';
 export default function NoteForm({
   onAdd,
 }: {
-  onAdd: (title: string, text: string, date: string) => Promise<boolean>;
+  onAdd: (title: string, text: string) => Promise<boolean>;
 }) {
   const [title, setTitle] = useState('');
   const [text, setText] = useState('');
-  const [date, setDate] = useState(() => new Date().toISOString().split('T')[0]);
   const [open, setOpen] = useState(false);
 
   function close() {
     setOpen(false);
     setTitle('');
     setText('');
-    setDate(new Date().toISOString().split('T')[0]);
   }
 
   async function handleSubmit(e: FormEvent) {
@@ -25,7 +23,7 @@ export default function NoteForm({
     const trimmedTitle = title.trim();
     const trimmedText = text.trim();
     if (!trimmedText && !trimmedTitle) return;
-    const saved = await onAdd(trimmedTitle, trimmedText, date);
+    const saved = await onAdd(trimmedTitle, trimmedText);
     if (saved) {
       close();
     }
@@ -44,11 +42,6 @@ export default function NoteForm({
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               placeholder="Title"
-            />
-            <input
-              type="date"
-              value={date}
-              onChange={(e) => setDate(e.target.value)}
             />
             <textarea
               autoFocus

--- a/components/NoteList.tsx
+++ b/components/NoteList.tsx
@@ -7,7 +7,7 @@ interface Note {
   id: string;
   title: string;
   text: string;
-  date: string;
+  created_at: string;
 }
 
 export default function NoteList({
@@ -71,7 +71,7 @@ export default function NoteList({
           >
             <span className="note-title">{note.title}</span>
             <span className="note-date">
-              {new Date(note.date).toLocaleDateString()}
+              {new Date(note.created_at).toLocaleDateString()}
             </span>
             <span className="note-text">{note.text}</span>
             <div className="note-actions">


### PR DESCRIPTION
## Summary
- Remove manual date field from note form and rely on Supabase `created_at`
- Adjust note list and page logic to display timestamps from `created_at`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be471bb1d483329e9bf4dd1006fd03